### PR TITLE
linux-etxx00: Fix build for new OE versions

### DIFF
--- a/recipes-bsp/linux/linux-etxx00-2g_3.13.8.bb
+++ b/recipes-bsp/linux/linux-etxx00-2g_3.13.8.bb
@@ -38,9 +38,9 @@ SRC_URI += "http://www.xtrendet.net/linux-${PV}.tar.gz \
 	file://mxl5007t-add-no_probe-and-no_reset-parameters.patch \
 	"
 
-S = "${WORKDIR}/linux-${PV}"
-
 inherit kernel machine_kernel_pr
+
+S = "${WORKDIR}/linux-${PV}"
 
 export OS = "Linux"
 KERNEL_OBJECT_SUFFIX = "ko"
@@ -49,11 +49,6 @@ KERNEL_IMAGETYPE = "vmlinux"
 KERNEL_IMAGEDEST = "/tmp"
 
 FILES_kernel-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}*"
-
-do_configure_prepend() {
-	oe_machinstall -m 0644 ${WORKDIR}/defconfig ${S}/.config
-	oe_runmake oldconfig
-}
 
 kernel_do_install_append() {
 	${STRIP} ${D}${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}-${KERNEL_VERSION}

--- a/recipes-bsp/linux/linux-etxx00-2g_3.14.16.bb
+++ b/recipes-bsp/linux/linux-etxx00-2g_3.14.16.bb
@@ -35,9 +35,9 @@ SRC_URI += "http://xtrendet.net/linux-${PV}.tar.gz \
 	file://mxl5007t-add-no_probe-and-no_reset-parameters.patch \
 	"
 
-S = "${WORKDIR}/linux-${PV}"
-
 inherit kernel machine_kernel_pr
+
+S = "${WORKDIR}/linux-${PV}"
 
 export OS = "Linux"
 KERNEL_OBJECT_SUFFIX = "ko"
@@ -46,11 +46,6 @@ KERNEL_IMAGETYPE = "vmlinux"
 KERNEL_IMAGEDEST = "/tmp"
 
 FILES_kernel-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}*"
-
-do_configure_prepend() {
-	oe_machinstall -m 0644 ${WORKDIR}/defconfig ${S}/.config
-	oe_runmake oldconfig
-}
 
 kernel_do_install_append() {
 	${STRIP} ${D}${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}-${KERNEL_VERSION}

--- a/recipes-bsp/linux/linux-etxx00-3g_3.14.21.bb
+++ b/recipes-bsp/linux/linux-etxx00-3g_3.14.21.bb
@@ -37,9 +37,9 @@ SRC_URI += "http://xtrendet.net/xtrend-linux-${PV}-${SRCDATE}.tar.gz \
 	file://timedate.patch \
 	"
 
-S = "${WORKDIR}/linux-${PV}"
-
 inherit kernel machine_kernel_pr
+
+S = "${WORKDIR}/linux-${PV}"
 
 export OS = "Linux"
 KERNEL_OBJECT_SUFFIX = "ko"
@@ -48,11 +48,6 @@ KERNEL_IMAGETYPE = "vmlinux"
 KERNEL_IMAGEDEST = "/tmp"
 
 FILES_kernel-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}*"
-
-do_configure_prepend() {
-	oe_machinstall -m 0644 ${WORKDIR}/defconfig ${S}/.config
-	oe_runmake oldconfig
-}
 
 kernel_do_install_append() {
 	${STRIP} ${D}${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}-${KERNEL_VERSION}

--- a/recipes-bsp/linux/linux-etxx00_3.8.7.bb
+++ b/recipes-bsp/linux/linux-etxx00_3.8.7.bb
@@ -52,9 +52,9 @@ SRC_URI += "http://www.xtrendet.net/linux-${PV}.tar.gz \
 	file://zl10353-output-full-range-SNR.patch \
 	"
 
-S = "${WORKDIR}/linux-${PV}"
-
 inherit kernel machine_kernel_pr
+
+S = "${WORKDIR}/linux-${PV}"
 
 export OS = "Linux"
 KERNEL_OBJECT_SUFFIX = "ko"
@@ -63,11 +63,6 @@ KERNEL_IMAGETYPE = "vmlinux"
 KERNEL_IMAGEDEST = "/tmp"
 
 FILES_kernel-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}*"
-
-do_configure_prepend() {
-	oe_machinstall -m 0644 ${WORKDIR}/defconfig ${S}/.config
-	oe_runmake oldconfig
-}
 
 kernel_do_install_append() {
 	${STRIP} ${D}${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}-${KERNEL_VERSION}


### PR DESCRIPTION
The kernel build recipes have undergone massive changes in newer
OpenEmbedded versions. This results in build failures like this:

| make: *** No rule to make target `oldconfig'.  Stop.

To resolve the issue, move the assignment of "S" to after the
"inherit kernel" statement, and remove the manual defconfig
handling, OE already takes care of that.